### PR TITLE
Fix dockerfile so notebooks directory is not copied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,3 @@ RUN pip install --user papermill psycopg2-binary
 ENV AIRFLOW_HOME=/usr/local/airflow
 
 COPY ./airflow.cfg /usr/local/airflow/airflow.cfg
-COPY ./notebooks /usr/local/airflow/notebooks


### PR DESCRIPTION
## Overview

- The notebooks directory is attached as a volume to the webserver in `docker-compose.yml`
- It should not be copied in `dockerfile` too
- This small fix PR removes the incorrect command from `dockerfile`
