### PR TITLE
Move papermill to requirements and invoke pip as python script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM puckel/docker-airflow:1.10.6
 
-RUN pip install --user --upgrade pip
-RUN pip install --user papermill psycopg2-binary
+RUN python -m pip install --user --upgrade pip
+RUN python -m pip install --user jupyter psycopg2-binary
+COPY requirements.txt /usr/local/airflow/
+RUN python -m pip install --user -r requirements.txt
 
 ENV AIRFLOW_HOME=/usr/local/airflow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-putting in some fake requirements
+papermill>=2.0<3.0


### PR DESCRIPTION
## Overview

This PR changes how some packages are installed in the docker build.

## Details
* Pip installs now invoked with `python -m` in keeping with a warning that the old way was becoming deprecated
* Move the installation of `papermill` to requirements text file so that version can be specified
* Copy the requirements file to the container and install all requirements listed (only one at the moment)