### PR TITLE
Raise exception if no API key and fix doc block

### DIFF
--- a/plugins/alphavantage_plugin/hooks/alphavantage_hook.py
+++ b/plugins/alphavantage_plugin/hooks/alphavantage_hook.py
@@ -25,6 +25,9 @@ class AlphavantageHook(HttpHook):
     
     def run(self, function: str, from_currency: str, to_currency: str):
 
+        if self.alphavantage_token is None:
+            raise ValueError("No API key provided")
+
         payload = {
             'function': function,
             'from_symbol': from_currency,
@@ -32,7 +35,5 @@ class AlphavantageHook(HttpHook):
             'apikey': self.alphavantage_token,
         }
 
-        if self.alphavantage_token:
-            return super().run(endpoint='', data=payload)
+        return super().run(endpoint='', data=payload)
 
-        # TODO: error handling for when alphavantage token not found

--- a/plugins/alphavantage_plugin/operators/alphavantage_to_s3_operator.py
+++ b/plugins/alphavantage_plugin/operators/alphavantage_to_s3_operator.py
@@ -10,7 +10,7 @@ from alphavantage_plugin.hooks.alphavantage_hook import AlphavantageHook
 
 class AlphavantageToS3Operator(BaseOperator):
     """
-    Fetches dataset from Alphavantage API and loads json into Postgres
+    Fetches dataset from Alphavantage API and loads json into S3
 
     :param alphavantage_conn_id: airflow connection for Alphavantage API
     :type alphavantage_conn_id: str


### PR DESCRIPTION
## Overview
This tiny PR contains two small fixes to the pipeline 

## Details
* Fix doc block description for `AlphavantageToS3Operator` as it referenced Postgres instead of S3
* Raise `TypeError` exception if no API key is set in `AlphavantageHook`